### PR TITLE
Fix: route graphql queries through apostrophecms

### DIFF
--- a/modules/@apostrophecms/graphql/generateResolvers.js
+++ b/modules/@apostrophecms/graphql/generateResolvers.js
@@ -9,13 +9,12 @@ module.exports = {
 
     for (const name of moduleNames) {
       const extend = modules[name].extend;
-      if ([ extend?.extend, extend ].includes('@apostrophecms/piece-type')) {
+      if ([extend?.extend, extend].includes('@apostrophecms/piece-type')) {
         const moduleName = snakeToPascal(name.replace('@apostrophecms/', ''));
         const schema = self.apos.modules[name].schema;
         if (schema.length) {
           queries[`get${moduleName}s`] = (_, __, { req }) => {
-            console.log(req);
-            return self.apos.modules[name.toLowerCase()].find(self.apos.task.getReq(), {}).toArray();
+            return self.apos.modules[name.toLowerCase()].find(req, {}).toArray();
           };
           resolvers[moduleName] = {};
         }
@@ -37,10 +36,7 @@ function generateStaticResolvers(self) {
   for (const name of moduleNames) {
     const dbModule = modules[name].db;
     if (dbModule?.s?.namespace) {
-      const collectionName = dbModule.s.namespace.collection.replace(
-        'apos',
-        ''
-      );
+      const collectionName = dbModule.s.namespace.collection.replace('apos', '');
       queries[`get${collectionName}`] = (a, b, ctx, c) => {
         return [];
       };

--- a/modules/@apostrophecms/graphql/generateTypeDefs.js
+++ b/modules/@apostrophecms/graphql/generateTypeDefs.js
@@ -9,7 +9,7 @@ module.exports = {
 
     for (const name of moduleNames) {
       const extend = modules[name].extend;
-      if ([ extend, extend?.extend ].includes('@apostrophecms/piece-type')) {
+      if ([extend, extend?.extend].includes('@apostrophecms/piece-type')) {
         const moduleName = snakeToPascal(name.replace('@apostrophecms/', ''));
         const schema = self.apos.modules[name].schema;
         if (schema.length) {
@@ -40,10 +40,7 @@ function generateStaticTypedefs(self) {
   for (const name of moduleNames) {
     const dbModule = modules[name].db;
     if (dbModule?.s?.namespace) {
-      const collectionName = dbModule.s.namespace.collection.replace(
-        'apos',
-        ''
-      );
+      const collectionName = dbModule.s.namespace.collection.replace('apos', '');
 
       types += `type ${collectionName} {\n
           name: String\n

--- a/modules/@apostrophecms/graphql/index.js
+++ b/modules/@apostrophecms/graphql/index.js
@@ -1,5 +1,5 @@
 const { ApolloServer } = require('@apollo/server');
-const { generateTypedefs } = require('./generateTypedefs.js');
+const { generateTypedefs } = require('./generateTypedefs');
 const { generateResolvers } = require('./generateResolvers');
 
 module.exports = {
@@ -15,15 +15,13 @@ module.exports = {
     await server.start();
     self.apos.modules.graphql.server = server;
   },
-  routes(self) {
+  restApiRoutes(self) {
     return {
-      post: {
-        // GET /api/v1/graphql/query
-        async query(req, res) {
-          const server = self.apos.modules.graphql.server;
-          const result = await server.executeOperation(req.body, { contextValue: { req } });
-          return res.send(result.body.singleResult.data);
-        }
+      // POST /api/v1/graphql
+      async post(req) {
+        const server = self.apos.modules.graphql.server;
+        const result = await server.executeOperation(req.body, { contextValue: { req } });
+        return result.body.singleResult.data;
       }
     };
   }


### PR DESCRIPTION
Apollo server was integrating directly into the express server as a middleware instead of using the Apostrophe routing, so the requests lacked user authentication information such as the role or the username.

Changes made:

- The default module `post` route (`POST /api/v1/graphql`) is overridden.
- Requests received through the Apostrophe router contain auth information to perform database operations.
- The query sent by the client in the request body is sent to Apollo server via `executeOperation()` function.
- Apollo server result is returned to the client.